### PR TITLE
date bindings. tests are WIP due to breaking symbol on mac. creating a PR just to review in browser...

### DIFF
--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -5,15 +5,18 @@ extern crate stdweb;
 extern crate serde_derive;
 extern crate serde_json;
 
+use std::collections::HashMap;
 use std::cell::RefCell;
 use std::rc::Rc;
 
 use stdweb::unstable::TryInto;
 use stdweb::web::{
+    IDate,
     IEventTarget,
     IElement,
     IHtmlElement,
     INode,
+    Date,
     HtmlElement,
     Element,
     document,
@@ -235,6 +238,23 @@ fn main() {
     window().add_event_listener( enclose!( (state) move |_: HashChangeEvent| {
         update_dom( &state );
     }));
+
+    let d: Date = js!( return new Date(); ).try_into().unwrap();
+    let todays_date: HtmlElement = document().query_selector( "header h2" ).unwrap().try_into().unwrap();
+
+    let options: HashMap< String, String > = [
+        ("weekday".to_string(), "long".to_string()),
+        ("year".to_string(),    "numeric".to_string()),
+        ("month".to_string(),   "long".to_string()),
+        ("day".to_string(),     "numeric".to_string()),
+    ].iter().cloned().collect();
+
+    let date_string = format!(
+        "{}",
+        d.to_locale_date_string(Some( &"en-US" ), Some( &options ))
+    );
+
+    todays_date.set_text_content( &date_string );
 
     update_dom( &state );
     stdweb::event_loop();

--- a/examples/todomvc/static/css/todomvc-app-css/index.css
+++ b/examples/todomvc/static/css/todomvc-app-css/index.css
@@ -83,6 +83,19 @@ input[type="checkbox"] {
 	text-rendering: optimizeLegibility;
 }
 
+.todoapp h2 {
+	position: absolute;
+	top: -40px;
+	width: 100%;
+	font-size: 24px;
+	font-weight: 100;
+	text-align: center;
+	color: rgba(175, 47, 47, 0.35);
+	-webkit-text-rendering: optimizeLegibility;
+	-moz-text-rendering: optimizeLegibility;
+	text-rendering: optimizeLegibility;
+}
+
 .new-todo,
 .edit {
 	position: relative;

--- a/examples/todomvc/static/index.html
+++ b/examples/todomvc/static/index.html
@@ -1,43 +1,45 @@
 <!doctype html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<title>stdweb • TodoMVC</title>
-		<link rel="stylesheet" href="css/todomvc-common/base.css">
-		<link rel="stylesheet" href="css/todomvc-app-css/index.css">
-	</head>
-	<body>
-		<section class="todoapp">
-			<header class="header">
-				<h1>todos</h1>
-				<input class="new-todo" placeholder="What needs to be done?" autofocus>
-			</header>
-			<section class="main">
-				<input class="toggle-all" type="checkbox">
-				<label for="toggle-all">Mark all as complete</label>
-				<ul class="todo-list"></ul>
-				<footer class="footer">
-					<span class="todo-count"></span>
-					<ul class="filters">
-						<li>
-							<a href="#/" class="selected">All</a>
-						</li>
-						<li>
-							<a href="#/active">Active</a>
-						</li>
-						<li>
-							<a href="#/completed">Completed</a>
-						</li>
-					</ul>
-					<button class="clear-completed">Clear completed</button>
-				</footer>
-			</section>
-		</section>
-		<footer class="info">
-			<p>Double-click to edit a todo</p>
-			<p>Part of the <a href="https://github.com/koute/stdweb">stdweb</a> project</p>
-			<p>Based on <a href="http://todomvc.com">TodoMVC</a></p>
-		</footer>
-		<script src="js/app.js"></script>
-	</body>
+    <head>
+        <meta charset="utf-8">
+        <title>stdweb • TodoMVC</title>
+        <link rel="stylesheet" href="css/todomvc-common/base.css">
+        <link rel="stylesheet" href="css/todomvc-app-css/index.css">
+    </head>
+    <body>
+        <section class="todoapp">
+            <header class="header">
+                <h1>todos</h1>
+                <h2 id='todays-date'></h2>
+                <input class="new-todo" placeholder="What needs to be done?" autofocus>
+            </header>
+            <section class="main">
+                <input class="toggle-all" type="checkbox">
+                <label for="toggle-all">Mark all as complete</label>
+                <ul class="todo-list"></ul>
+                <footer class="footer">
+                    <span class="todo-count"></span>
+                    <ul class="filters">
+                        <li>
+                            <a href="#/" class="selected">All</a>
+                        </li>
+                        <li>
+                            <a href="#/active">Active</a>
+                        </li>
+                        <li>
+                            <a href="#/completed">Completed</a>
+                        </li>
+                    </ul>
+                    <button class="clear-completed">Clear completed</button>
+                </footer>
+            </section>
+        </section>
+        <footer class="info">
+            <p>Double-click to edit a todo</p>
+            <p>Part of the <a href="https://github.com/koute/stdweb">stdweb</a> project</p>
+            <p>Based on <a href="http://todomvc.com">TodoMVC</a></p>
+        </footer>
+        <script src="js/app.js"></script>
+    </body>
 </html>
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub mod web {
         alert
     };
     pub use webapi::cross_origin_setting::CrossOriginSetting;
-    pub use webapi::date::Date;
+    pub use webapi::date::{IDate, Date};
     pub use webapi::event_target::{IEventTarget, EventTarget, EventListenerHandle};
     pub use webapi::node::{INode, Node, CloneKind};
     pub use webapi::element::{IElement, Element};
@@ -227,3 +227,4 @@ pub mod private {
     #[inline(always)]
     pub fn noop< T >( _: &mut T ) {}
 }
+

--- a/src/webapi/date.rs
+++ b/src/webapi/date.rs
@@ -899,15 +899,5 @@ mod tests {
     fn test_value_of() {
 
     }
-
-    #[test]
-    fn test_() {
-
-    }
-
-    #[test]
-    fn test_() {
-
-    }
 }
 

--- a/src/webapi/date.rs
+++ b/src/webapi/date.rs
@@ -1,22 +1,913 @@
-use std::marker::PhantomData;
+use std::collections::HashMap;
+use webcore::try_from::{TryFrom, TryInto};
+use webcore::value::{Value, Reference};
 
-/// [(JavaScript docs)](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date)
-#[derive(Debug)]
-pub struct Date {
-    dummy: PhantomData< () >
-}
-
-impl Date {
+/// A date object
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/API/Date)
+pub trait IDate: AsRef< Reference > + TryFrom< Value >  {
     /// The Date.now() method returns the number of milliseconds elapsed since 1 January 1970 00:00:00 UTC.
     ///
     /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now)
-    pub fn now() -> f64 {
-        em_asm_double!( "return Date.now();" )
+    #[inline]
+    fn now() -> f64 {
+        // em_asm_double!( "return Date.now();" )
+        js!( return Date.now(); ).try_into().unwrap()
+    }
+
+    /// Date.utc
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/utc)
+    #[inline]
+    fn utc(args: &[i32] ) -> f64 {
+        // args represents:
+        // [<year_value>, <month_value>, <day_value>, <hour_value>, <minute_value>,
+        // <second_value>, <millisecond_value>]
+        match args.len() {
+            7 => {
+                let date_obj: HashMap< String, Value > = [
+                    ("year".to_string(),        Value::Number( args[0].into())),
+                    ("month".to_string(),       Value::Number( args[1].into())),
+                    ("day".to_string(),         Value::Number( args[2].into())),
+                    ("hour".to_string(),        Value::Number( args[3].into())),
+                    ("minute".to_string(),      Value::Number( args[4].into())),
+                    ("second".to_string(),      Value::Number( args[5].into())),
+                    ("millisecond".to_string(), Value::Number( args[6].into()))
+                ].iter().cloned().collect();
+
+                js!(
+                    var dateObj = @{date_obj};
+
+                    return Date.UTC(
+                        dateObj.year,
+                        dateObj.month,
+                        dateObj.day,
+                        dateObj.hour,
+                        dateObj.minute,
+                        dateObj.second,
+                        dateObj.millisecond
+                    );
+                ).try_into().unwrap()
+            },
+            6 => {
+                let date_obj: HashMap< String, Value > = [
+                    ("year".to_string(),        Value::Number( args[0].into())),
+                    ("month".to_string(),       Value::Number( args[1].into())),
+                    ("day".to_string(),         Value::Number( args[2].into())),
+                    ("hour".to_string(),        Value::Number( args[3].into())),
+                    ("minute".to_string(),      Value::Number( args[4].into())),
+                    ("second".to_string(),      Value::Number( args[5].into()))
+                ].iter().cloned().collect();
+
+                js!(
+                    var dateObj = @{date_obj};
+
+                    return Date.UTC(
+                        dateObj.year,
+                        dateObj.month,
+                        dateObj.day,
+                        dateObj.hour,
+                        dateObj.minute,
+                        dateObj.second
+                    );
+                ).try_into().unwrap()
+            },
+            5 => {
+                let date_obj: HashMap< String, Value > = [
+                    ("year".to_string(),        Value::Number( args[0].into())),
+                    ("month".to_string(),       Value::Number( args[1].into())),
+                    ("day".to_string(),         Value::Number( args[2].into())),
+                    ("hour".to_string(),        Value::Number( args[3].into())),
+                    ("minute".to_string(),      Value::Number( args[4].into()))
+                ].iter().cloned().collect();
+
+                js!(
+                    var dateObj = @{date_obj};
+
+                    return Date.UTC(
+                        dateObj.year,
+                        dateObj.month,
+                        dateObj.day,
+                        dateObj.hour,
+                        dateObj.minute
+                    );
+                ).try_into().unwrap()
+            },
+            4 => {
+                js!( return Date.UTC( @{args[0]}, @{args[1]}, @{args[2]}, @{args[3]} ); ).try_into().unwrap()
+            },
+            3 => {
+                js!( return Date.UTC( @{args[0]}, @{args[1]}, @{args[2]} ); ).try_into().unwrap()
+            },
+            2 => {
+                js!( return Date.UTC( @{args[0]}, @{args[1]} ); ).try_into().unwrap()
+            },
+            1 => js!( return Date.UTC( @{args[0]}); ).try_into().unwrap(),
+            _ => js!( return Date.UTC(); ).try_into().unwrap(),
+        }
+    }
+
+    /// The Date.parse method parses a string representation of a date, and returns the number of
+    /// milliseconds since 1 January 1970 00:00:00 UTC, or NaN if the string is unrecognize or, in
+    /// some cases, contains illegal data values (e.g. 2015-02-31)
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse)
+    #[inline]
+    fn parse( _date_string: &str ) -> f64 {
+        em_asm_double!( "return Date.parse(@{_date_string}" )
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate)
+    #[inline]
+    fn get_date( &self ) -> i32 {
+        js!( return @{self.as_ref()}.getDate() ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay)
+    #[inline]
+    fn get_day( &self ) -> i32 {
+        js!( return @{self.as_ref()}.getDay(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getFullYear)
+    #[inline]
+    fn get_full_year( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getFullYear(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getHours)
+    #[inline]
+    fn get_hours( &self) -> f64 {
+        js!( return @{self.as_ref()}.getHours(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMilliseconds)
+    #[inline]
+    fn get_milliseconds( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getMilliseconds(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMinutes)
+    #[inline]
+    fn get_minutes( &self ) -> i16 {
+        js!( return @{self.as_ref()}.getMinutes(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth)
+    #[inline]
+    fn get_month( &self ) -> i8 {
+        js!( return @{self.as_ref()}.getMonth(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getSeconds)
+    #[inline]
+    fn get_seconds( &self ) -> i16 {
+        js!( return @{self.as_ref()}.getSeconds(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime)
+    #[inline]
+    fn get_time( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getTime(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset)
+    #[inline]
+    fn get_timezone_offset( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getTimezoneOffset(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDate)
+    #[inline]
+    fn get_utc_date( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getUTCDate(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDay)
+    #[inline]
+    fn get_utc_day( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getUTCDay(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCFullYear)
+    #[inline]
+    fn get_utc_full_year( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getUTCFullYear(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCHours)
+    #[inline]
+    fn get_utc_hours( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getUTCHours(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMilliseconds)
+    #[inline]
+    fn get_utc_milliseconds( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getUTCMilliseconds(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMinutes)
+    #[inline]
+    fn get_utc_minutes( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getUTCMinutes(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMonth)
+    #[inline]
+    fn get_utc_month( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getUTCMonth(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCSeconds)
+    #[inline]
+    fn get_utc_seconds( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getUTCSeconds(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getYear)
+    #[inline]
+    fn get_year( &self ) -> f64 {
+        js!( return @{self.as_ref()}.getYear(); ).try_into().unwrap()
+    }
+
+    /// NOTE: for the following functions that take arguments in addition to self, the arguments
+    /// are allowed to be empty. From the user's perspective, the first argument is mandatory, with
+    /// the rest optional. However, browsers do not need all arguments, even the first, but calling
+    /// with empty arguments returns NaN.
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setDate)
+    #[inline]
+    fn set_date( &self, _day_value: f64 ) -> f64 {
+        js!( return @{self.as_ref()}.setDate(@{_day_value}); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setFullYear)
+    #[inline]
+    fn set_full_year( &self, args: &[i32] ) -> f64 {
+        // args represents:
+        // [<year_value>, <month_value>, <day_value>]
+
+        match args.len() {
+            3 => {
+                let args_obj: HashMap< String, Value > = [
+                    ("year".to_string(),  Value::Number( args[0].into())),
+                    ("month".to_string(), Value::Number( args[1].into())),
+                    ("day".to_string(),   Value::Number( args[2].into()))
+                ].iter().cloned().collect();
+
+                js!(
+                    var args = @{args_obj};
+                    return @{self.as_ref()}.setFullYear(args.year, args.month, args.day);
+                ).try_into().unwrap()
+            },
+            2 => {
+                js!(
+                    return @{self.as_ref()}.setFullYear(@{args[0]}, @{args[1]});
+                ).try_into().unwrap()
+            },
+            1 => {
+                js!(
+                    return @{self.as_ref()}.setFullYear(@{args[0]});
+                ).try_into().unwrap()
+            },
+            _ => js!( return @{self.as_ref()}.setFullYear(); ).try_into().unwrap()
+        }
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setHours)
+    #[inline]
+    fn set_hours( &self, args: &[i32] ) -> f64 {
+        // args represents:
+        // [<hours_value>, <minutes_value>, <seconds_value>, <ms_value>]
+        match args.len() {
+            4 => {
+                let args_obj: HashMap< String, Value > = [
+                    ("hours".to_string(),   Value::Number( args[0].into())),
+                    ("minutes".to_string(), Value::Number( args[1].into())),
+                    ("seconds".to_string(), Value::Number( args[2].into())),
+                    ("ms".to_string(),      Value::Number( args[2].into()))
+                ].iter().cloned().collect();
+
+                js!(
+                    var args = @{args_obj};
+                    return @{self.as_ref()}.setHours(args.hours, args.minutes, args.seconds, args.ms);
+                ).try_into().unwrap()
+            },
+            3 => {
+                js!(
+                    return @{self.as_ref()}.setHours(@{args[0]}, @{args[1]}, @{args[2]});
+                ).try_into().unwrap()
+            },
+            2 => {
+                js!(
+                    return @{self.as_ref()}.setHours(@{args[0]}, @{args[1]});
+                ).try_into().unwrap()
+            },
+            1 => {
+                js!( return @{self.as_ref()}.setHours(@{args[0]}); ).try_into().unwrap()
+            },
+            _ => js!( return @{self.as_ref()}.setHours(); ).try_into().unwrap()
+        }
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMilliseconds)
+    #[inline]
+    fn set_milliseconds( &self, _milliseconds_value: f64 ) -> f64 {
+        js!( return @{self.as_ref()}.setMilliseconds(@{_milliseconds_value}); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMinutes)
+    #[inline]
+    fn set_minutes( &self, args: &[i32] ) -> f64 {
+        // args represents:
+        // [<minutes_value>, <seconds_value>, <ms_value>]
+        match args.len() {
+            3 => js!(
+                return @{self.as_ref()}.setMinutes(@{args[0]}, @{args[1]}, @{args[2]});
+            ).try_into().unwrap(),
+            2 => js!( return @{self.as_ref()}.setMinutes(@{args[0]}, @{args[1]}); ).try_into().unwrap(),
+            1 => js!( return @{self.as_ref()}.setMinutes(@{args[0]}); ).try_into().unwrap(),
+            _ => js!( return @{self.as_ref()}.setMinutes();).try_into().unwrap()
+        }
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMonth)
+    #[inline]
+    fn set_month( &self, args: &[i32] ) -> f64 {
+        // args represents:
+        // [<month_value>, <day_value>]
+        match args.len() {
+            2 => js!( return @{self.as_ref()}.setMonth(@{args[0]}, @{args[1]}); ).try_into().unwrap(),
+            1 => js!( return @{self.as_ref()}.setMonth(@{args[0]}); ).try_into().unwrap(),
+            _ => js!( return @{self.as_ref()}.setMonth(); ).try_into().unwrap()
+        }
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setSeconds)
+    #[inline]
+    fn set_seconds( &self, args: &[i32] ) -> f64 {
+        // args represents:
+        // [<seconds_value>, <ms_value>]
+        match args.len() {
+            2 => js!( return @{self.as_ref()}.setSeconds(@{args[0]}, @{args[1]}); ).try_into().unwrap(),
+            1 => js!( return @{self.as_ref()}.setSeconds(@{args[0]}); ).try_into().unwrap(),
+            _ => js!( return @{self.as_ref()}.setSeconds(); ).try_into().unwrap()
+        }
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setTime)
+    #[inline]
+    fn set_time( &self, _time_value: f64 ) -> f64 {
+        js!( return @{self.as_ref()}.setTime(@{_time_value}); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCDate)
+    #[inline]
+    fn set_utc_date( &self, _day_value: f64 ) -> f64 {
+        js!( return @{self.as_ref()}.setUTCDate(@{_day_value}); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCFullYear)
+    #[inline]
+    fn set_utc_full_year( &self, _year_value: f64, _month_value: f64, _day_value: f64 ) -> f64 {
+        js!(
+            return @{self.as_ref()}.setUTCFullYear(@{_year_value}, @{_month_value}, @{_day_value});
+        ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCHours)
+    #[inline]
+    fn set_utc_hours( &self, args: &[i32] ) -> f64 {
+        // args represents:
+        // [<hours_value>, <minutes_value>, <seconds_value>, <ms_value>]
+        match args.len() {
+            4 => {
+                let args_obj: HashMap< String, Value > = [
+                    ("hours".to_string(),   Value::Number( args[0].into())),
+                    ("minutes".to_string(), Value::Number( args[1].into())),
+                    ("seconds".to_string(), Value::Number( args[2].into())),
+                    ("ms".to_string(),      Value::Number( args[2].into()))
+                ].iter().cloned().collect();
+
+                js!(
+                    var args = @{args_obj};
+                    return @{self.as_ref()}.setUTCHours(args.hours, args.minutes, args.seconds, args.ms);
+                ).try_into().unwrap()
+            },
+            3 => js!(
+                return @{self.as_ref()}.setUTCHours(@{args[0]}, @{args[1]}, @{args[2]});
+            ).try_into().unwrap(),
+            2 => js!( return @{self.as_ref()}.setUTCHours(@{args[0]}, @{args[1]}); ).try_into().unwrap(),
+            1 => js!( return @{self.as_ref()}.setUTCHours(@{args[0]}); ).try_into().unwrap(),
+            _ => js!( return @{self.as_ref()}.setUTCHours(); ).try_into().unwrap()
+        }
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMilliseconds)
+    #[inline]
+    fn set_utc_milliseconds( &self, _milliseconds_value: f64 ) -> f64 {
+        js!( return @{self.as_ref()}.setUTCMilliseconds(@{_milliseconds_value}); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMinutes)
+    #[inline]
+    fn set_utc_minutes( &self, args: &[i32] ) -> f64 {
+        // args represents:
+        // [<minutes_value>, <seconds_value>, <ms_value>]
+        match args.len() {
+            3 => js!(
+                return @{self.as_ref()}.setUTCMinutes(@{args[0]}, @{args[1]}, @{args[2]});
+            ).try_into().unwrap(),
+            2 => js!( return @{self.as_ref()}.setUTCMinutes(@{args[0]}, @{args[1]}); ).try_into().unwrap(),
+            1 => js!( return @{self.as_ref()}.setUTCMinutes(@{args[0]}); ).try_into().unwrap(),
+            _ => js!( return @{self.as_ref()}.setUTCMinutes(); ).try_into().unwrap()
+
+        }
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMonth)
+    #[inline]
+    fn set_utc_month( &self, args: &[i32] ) -> f64 {
+        // args represents:
+        // [<month_value>, <day_value>]
+        match args.len() {
+            2 => js!( return @{self.as_ref()}.setUTCMonth(@{args[0]}, @{args[1]}); ).try_into().unwrap(),
+            1 => js!( return @{self.as_ref()}.setUTCMonth(@{args[0]}); ).try_into().unwrap(),
+            _ => js!( return @{self.as_ref()}.setUTCMonth(); ).try_into().unwrap()
+
+        }
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCSeconds)
+    #[inline]
+    fn set_utc_seconds( &self, args: &[i32] ) -> f64 {
+        // args represents:
+        // [<seconds_value>, <ms_value>]
+        match args.len() {
+            2 => js!( return @{self.as_ref()}.setUTCSeconds(@{args[0]}, @{args[1]}); ).try_into().unwrap(),
+            1 => js!( return @{self.as_ref()}.setUTCSeconds(@{args[0]}); ).try_into().unwrap(),
+            _ => js!( return @{self.as_ref()}.setUTCSeconds(); ).try_into().unwrap()
+
+        }
+    }
+
+    /// DEPRECATED
+    /// fn set_year() -> f64 { }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toDateString)
+    #[inline]
+    fn to_date_string( &self ) -> String {
+        js! ( return @{self.as_ref()}.toDateString; ).try_into().unwrap()
+    }
+
+    /// DEPRECATED
+    /// fn to_gmt_string( &self ) -> f64 { }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+    #[inline]
+    fn to_iso_string( &self ) -> String {
+        js! ( return @{self.as_ref()}.toISOString(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON)
+    #[inline]
+    fn to_json( &self ) -> String {
+        js! ( return @{self.as_ref()}.toJSON(); ).try_into().unwrap()
+    }
+
+    /// to_locale_date_string
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString)
+    #[inline]
+    fn to_locale_date_string( &self, _locales: Option< &str >, _options: Option< &HashMap< String, String > >) -> String {
+        match _locales {
+            Some(_locales) => match _options {
+                Some(_options) => return js! (
+                    var _options = @{_options};
+
+                    return @{self.as_ref()}.toLocaleDateString(@{_locales}, _options);
+                 ).try_into().unwrap(),
+
+                 None => return js! (
+                     return @{self.as_ref()}.toLocaleDateString(@{_locales});
+                 ).try_into().unwrap()
+            },
+
+            None => return js! ( return @{self.as_ref()}.toLocaleDateString(); ).try_into().unwrap()
+        }
+
+    }
+
+    /// NON-STANDARD
+    /// fn to_locale_format( &self ) -> f64 { }
+
+    /// to_locale_string
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString)
+    #[inline]
+    fn to_locale_string( &self, _locales: Option< &str >, _options: Option< &HashMap< String, String > >) -> String {
+        match _locales {
+            Some(_locales) => match _options {
+                Some(_options) => return js! (
+                    var _options = @{_options};
+
+                    return @{self.as_ref()}.toLocaleString(@{_locales}, _options);
+                ).try_into().unwrap(),
+
+                None => return js! (
+                    return @{self.as_ref()}.toLocaleString(@{_locales});
+                ).try_into().unwrap()
+            },
+
+            None => return js! ( return @{self.as_ref()}.toLocaleString(); ).try_into().unwrap()
+        }
+    }
+
+    /// to_locale_time_string
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString)
+    #[inline]
+    fn to_locale_time_string( &self, _locales: Option< &str >, _options: Option< &HashMap< String, String > > ) -> String {
+        match _locales {
+            Some(_locales) => match _options {
+                Some(_options) => return js! (
+                    var _options = @{_options};
+
+                    return @{self.as_ref()}.toLocaleTimeString(@{_locales}, _options);
+                ).try_into().unwrap(),
+
+                None => return js! (
+                    return @{self.as_ref()}.toLocaleTimeString(@{_locales});
+                ).try_into().unwrap()
+            },
+
+            None => return js! ( return @{self.as_ref()}.toLocaleTimeString(); ).try_into().unwrap()
+        }
+    }
+
+    /// NON-STANDARD
+    /// fn to_source( &self ) -> f64 { }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toString)
+    #[inline]
+    fn toString( &self ) -> String {
+        js! ( return @{self.as_ref()}.toString(); ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toTimeString)
+    #[inline]
+    fn to_time_string( &self ) -> String {
+        js! ( return @{self.as_ref()}.toTimeString; ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString)
+    #[inline]
+    fn to_utc_string( &self ) -> String {
+        js! ( return @{self.as_ref()}.toUTCString; ).try_into().unwrap()
+    }
+
+    ///
+    ///
+    /// [(JavaScript docs)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf)
+    #[inline]
+    fn value_of( &self ) -> f64 {
+        js!( return @{self.as_ref()}.valueOf(); ).try_into().unwrap()
     }
 }
 
-#[test]
-fn test_date_now() {
-    let now = Date::now();
-    assert!( now > 0.0 );
+/// A reference to a JavaScript object which implements the [IDate](trait.IDate.html)
+/// interface.
+///
+/// [(JavaScript docs)](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date)
+pub struct Date( Reference );
+
+impl IDate for Date {}
+
+reference_boilerplate! {
+    Date,
+    instanceof Date
 }
+
+/////////////////////////////////////////////////////////////////////
+
+#[cfg(web_api_tests)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_now() {
+        let now = Date::now();
+
+        /// could make test assertion more specific...
+        assert!( now > 0.0 );
+    }
+
+    #[test]
+    fn test_utc() {
+
+    }
+
+    #[test]
+    fn test_parse() {
+
+    }
+
+    #[test]
+    fn test_get_date() {
+
+    }
+
+    #[test]
+    fn test_get_day() {
+
+    }
+
+    #[test]
+    fn test_get_full_year() {
+
+    }
+
+    #[test]
+    fn test_get_hours() {
+
+    }
+
+    #[test]
+    fn test_get_milliseconds() {
+
+    }
+
+    #[test]
+    fn test_get_minutes() {
+
+    }
+
+    #[test]
+    fn test_get_month() {
+
+    }
+
+    #[test]
+    fn test_get_seconds() {
+
+    }
+
+    #[test]
+    fn test_get_time() {
+
+    }
+
+    #[test]
+    fn test_get_timezone_offset() {
+
+    }
+
+    #[test]
+    fn test_get_utc_date() {
+
+    }
+
+    #[test]
+    fn test_get_utc_day() {
+
+    }
+
+    #[test]
+    fn test_get_utc_full_year() {
+
+    }
+
+    #[test]
+    fn test_utc_milliseconds() {
+
+    }
+
+    #[test]
+    fn test_get_utc_minutes() {
+
+    }
+
+    #[test]
+    fn test_get_utc_month() {
+
+    }
+
+    #[test]
+    fn test_get_utc_seconds() {
+
+    }
+
+    #[test]
+    fn test_get_year() {
+
+    }
+
+    #[test]
+    fn test_set_date() {
+
+    }
+
+    #[test]
+    fn test_set_full_year() {
+
+    }
+
+    #[test]
+    fn test_set_hours() {
+
+    }
+
+    #[test]
+    fn test_set_milliseconds() {
+
+    }
+
+    #[test]
+    fn test_set_minutes() {
+
+    }
+
+    #[test]
+    fn test_set_month() {
+
+    }
+
+    #[test]
+    fn test_set_seconds() {
+
+    }
+    #[test]
+    fn test_set_time() {
+
+    }
+    #[test]
+    fn test_set_utc_date() {
+
+    }
+    #[test]
+    fn test_set_utc_full_year() {
+
+    }
+    #[test]
+    fn test_set_utc_hours() {
+
+    }
+    #[test]
+    fn test_set_utc_milliseconds() {
+
+    }
+    #[test]
+    fn test_set_utc_minutes() {
+
+    }
+    #[test]
+    fn test_set_utc_month() {
+
+    }
+    #[test]
+    fn test_set_utc_seconds() {
+
+    }
+
+    #[test]
+    fn test_to_date_string() {
+
+    }
+
+    #[test]
+    fn test_to_iso_string() {
+
+    }
+
+    #[test]
+    fn test_to_json() {
+
+    }
+
+    #[test]
+    fn test_to_locale_date_string() {
+
+    }
+
+    #[test]
+    fn test_to_locale_string() {
+
+    }
+
+    #[test]
+    fn test_to_locale_time_string() {
+
+    }
+
+    #[test]
+    fn test_to_string() {
+
+    }
+
+    #[test]
+    fn test_to_time_string() {
+
+    }
+
+    #[test]
+    fn test_to_utc_string() {
+
+    }
+
+    #[test]
+    fn test_value_of() {
+
+    }
+
+    #[test]
+    fn test_() {
+
+    }
+
+    #[test]
+    fn test_() {
+
+    }
+}
+

--- a/src/webapi/date.rs
+++ b/src/webapi/date.rs
@@ -330,7 +330,7 @@ pub trait IDate: AsRef< Reference > + TryFrom< Value >  {
                     ("hours".to_string(),   Value::Number( args[0].into())),
                     ("minutes".to_string(), Value::Number( args[1].into())),
                     ("seconds".to_string(), Value::Number( args[2].into())),
-                    ("ms".to_string(),      Value::Number( args[2].into()))
+                    ("ms".to_string(),      Value::Number( args[3].into()))
                 ].iter().cloned().collect();
 
                 js!(
@@ -447,7 +447,7 @@ pub trait IDate: AsRef< Reference > + TryFrom< Value >  {
                     ("hours".to_string(),   Value::Number( args[0].into())),
                     ("minutes".to_string(), Value::Number( args[1].into())),
                     ("seconds".to_string(), Value::Number( args[2].into())),
-                    ("ms".to_string(),      Value::Number( args[2].into()))
+                    ("ms".to_string(),      Value::Number( args[3].into()))
                 ].iter().cloned().collect();
 
                 js!(


### PR DESCRIPTION
Comments:

1. Some API changes:
    - any javascript function that takes more than one variable (let's
call the function "variadic"), e.g. ```Date.utc()```, differs from the browser
API in that instead of taking several optional strings representing
various date constructs, we use an array of ```String``` here. This is
because Rust does not support optional arguments (as of 12/9/2017). One
way to have implemented this would be to use macros that could expand on
any given number of arguments, but this would cause the Date API to
become clumsy. A developer/consumer would have to know when a Date
method is a macro and when it is not (e.g. when to call ```Date::utc()``` vs
```date_utc!()```). Further, exporting macros is an
experimental feature in Rust at the moment and the current lib.rs
configuration is set up to block unstable features, for good reason. But
worst of all, making what should be an instance method a macro lead to
significant challenges. So, the solution here was to pass in an array representing the normal
arguments for the Date module as represented in the browser.
    - types may be confusing at the moment. In an effort to keep
memory footprint low, I've been specific in laying out types for some, but not all,
functions (e.g. if we're returning a month number, f64 is huge for a
value between 1 and 12). That said, pretty much everything in javascript
is represented as a float, but with emscripten in the mix, it would be
great to be able to optimize some of these calls, before they make it to
the javascript world, as an extension of the C++ source of emscripten.
The whole point of being able to compile to (W)ASM is performance! I
hope the types are appopriate, both in the above reasoning and to
reflect current browser usage (the Date API)
    - the string methods ```to_locale_date_string```,
```to_locale_string```, and ```to_locale_time_string``` all take two
(optional) arguments: locales and options. Instead of keeping with (I)
and making this an array API (e.g. ```to_locale_date_string([locales,
options])``` or ```to_locale_date_string()``` or
```to_locale_date_string([locales])```), I've made this require an API as ```to_locale_date_string(Option< &str >, Option< &HashMap < String, String > >)``` so a developer/consumer will need to provide "None" if options and/or locale is not used
    - at the moment, sending locales as an array is not supported (TODO)

2. tests are not working due to

> Undefined symbols for architecture x86_64:
            "_emscripten_asm_const_int", referenced from:
                stdweb::webcore::value::Reference::from_raw_unchecked::hdbe203e0bb5dc861
in stdweb-d4848b03526ad141.stdweb1.rust-cgu.o
                _$LT$stdweb..webcore..value..Reference$u20$as$u20$core..ops..drop..Drop$GT$::drop::hd165fb3c2d7a11e6
in stdweb-d4848b03526ad141.stdweb1.rust-cgu.o
                stdweb::webcore::serialization::test_reserialization::i32::h18b05559d6914218
in stdweb-d4848b03526ad141.stdweb11.rust-cgu.o
                stdweb::webcore::serialization::test_reserialization::f64::hc629b32196a9e3cd
in stdweb-d4848b03526ad141.stdweb11.rust-cgu.o
                stdweb::webcore::serialization::test_reserialization::bool_true::h9c3b07d7362c2e53
in stdweb-d4848b03526ad141.stdweb11.rust-cgu.o
                stdweb::webcore::serialization::test_reserialization::bool_false::h677c538fa5c59948
in stdweb-d4848b03526ad141.stdweb11.rust-cgu.o
                stdweb::webcore::serialization::test_reserialization::undefined::hb9cfb96ef38391f7
in stdweb-d4848b03526ad141.stdweb11.rust-cgu.o
                ...
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v
to see invocation)

3. For the functions taking optional arguments, they could definitely be
cleaned up to not need to expand arguments into a ```JsSerializable``` ```HashMap```.
However, there is a known issue (#5) with the ```js!``` macro; any argument after the third (meaning the fourth argument breaks) throws an expansion error. Further, there is also an issue with the ```em_asm_double!``` (and presumably, any other ```em_asm_<data_type>!``` macro) where ```@{}``` syntax breaks on ```self```

4. The CSS I added could be refactored/changed as need be

5. I slightly changed the example TodoApp to use the new Date API. It
would be cool to add a "realtime" timer to the app (TODO).

6. This Date API could be used in the future by libraries built on top
of this, a la MomentJs, say

7. I changed tabs to spaces in index.html...perfectly fine with either